### PR TITLE
Fix error with linting local files.

### DIFF
--- a/cmd/pods.go
+++ b/cmd/pods.go
@@ -58,13 +58,13 @@ var podsCmd = &cobra.Command{
 		}
 
 		inputPods := []v1.Pod{}
-		if kubeconfig != "" {
-			inputPods = pods.NewKubeServer(kubeconfig).GetPods(namespace)
-		} else if filename != "" {
+		if filename != "" {
+			fmt.Println("Getting pods for", filename)
 			inputPods = pods.NewLocalFilesystem(filename).GetPods()
 		} else {
-			fmt.Println("[ERROR] --filename or --kubeconfig required")
-			os.Exit(1)
+			// kubeconfig has a default value so will always be populated
+			fmt.Println("Getting pods for", kubeconfig)
+			inputPods = pods.NewKubeServer(kubeconfig).GetPods(namespace)
 		}
 
 		if len(inputPods) == 0 {


### PR DESCRIPTION
The kubeconfig option has a default value so the filename option was
never checked. This is espically frustrating if the default kube config
isn't setup properly and the app has to timeout on connecting to k8s.
Swapped to logic to check filename and then fallback to kubeconfig.